### PR TITLE
Adapt the Kai Tak, HK marimo notebook test such that it runs with latest code

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9']
+        python-version: ['3.9', '3.12']
 
     steps:
     - name: Checkout code

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,15 +14,11 @@ Update the version number in:
 - [`/src/bedrock/__init__.py`](/src/bedrock_ge/__init__.py)
 - Inline script dependencies of marimo notebooks in [`examples`](/examples/)
 
-## 2. Update the Changelog
+## 3. PR `dev` → `main`
 
-Update `CHANGELOG.md` with details about the new release. Include any new features, bug fixes, or breaking changes.
+Open a pull request (PR) from `dev` to `main`.
 
-## 3. Run Tests
-
-Ensure that all tests pass by running your test suite.
-
-To automate this, it's possible to set up a CI (Continuous Integration) pipeline to confirm everything works in multiple environments, e.g. with `GitHub Actions`.
+This also runs the automated tests.
 
 ## 4. Commit the Changes
 
@@ -33,15 +29,11 @@ git add .
 git commit -m "Release version X.Y.Z"
 ```
 
-## 5. Prepare for Merge
-
-Open a pull request (PR) from `dev` to `main`.
-
-## 6. Merge `dev` into `main`
+## 5. Merge `dev` into `main`
 
 Once everything is ready, and the PR is approved, merge `dev` into `main`. This officially brings all the changes in `dev` into the release-ready `main` branch.
 
-## 7. Tag the Release
+## 6. Tag the Release
 
 Create a Git tag for the new version:
 
@@ -51,13 +43,19 @@ git tag X.Y.Z
 git push origin X.Y.Z
 ```
 
-## 8. Build the Distribution
+## 7. Build the Distribution
 
 Create source and wheel distributions:
 
 ```bash
 uv build
 ```
+
+This creates a `bedrock_ge-X.Y.Z.tar.gz` file (source) and a `bedrock_ge-X.Y.Z-py3-none-any.whl` file (wheel) in the `/dist` folder.
+
+## 8. Remove the old distribution
+
+In order for the `uv publish` command to work properly, only one version of the distriution can be inside the `/dist` folder. Therefore delete the old source and wheel files.
 
 ## 9. Publish to PyPI
 
@@ -68,10 +66,6 @@ uv build
 set UV_PUBLISH_TOKEN=pypi-blablabla
 uv publish
 ```
-
-> ⚠️ **Attention:**
->
-> You might have to delete previous distributions of the Python package in `dist/*`
 
 ## 10. Verify the Release
 

--- a/examples/hk_kaitak_ags3/hk_kaitak_ags3_to_brgi_geodb.py
+++ b/examples/hk_kaitak_ags3/hk_kaitak_ags3_to_brgi_geodb.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "bedrock-ge==0.2.3",
+#     "bedrock-ge==0.2.4",
 #     "chardet==5.2.0",
 #     "folium==0.19.5",
 #     "geopandas==1.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,9 @@ Tracker = "https://github.com/bedrock-engineer/bedrock-ge/issues"
 [dependency-groups]
 dev = [
     "duckdb>=1.2.2",
-    "folium>=0.17.0",
     "frictionless[excel]>=4.40.8",
     "jupyter>=1.1.1",
-    "mapclassify>=2.8.1",
     "marimo>=0.12.5",
-    "matplotlib>=3.9.2",
     "mypy>=1.11.2",
     "nbconvert>=7.16.6",
     "pandas-stubs>=2.2.2.240807",
@@ -87,6 +84,9 @@ dev = [
 ]
 
 tests = [
+    "folium>=0.17.0",
+    "mapclassify>=2.8.1",
+    "matplotlib>=3.9.2",
     "pytest>=8.3.3",
 ]
 

--- a/tests/test_examples/test_hk_kaitak_ags3_to_brgi_geodb.py
+++ b/tests/test_examples/test_hk_kaitak_ags3_to_brgi_geodb.py
@@ -44,7 +44,8 @@ def test_kaitak_ags3_notebook_runs_and_creates_gpkg(examples_dir):
         env = os.environ.copy()
         env["PYTHONIOENCODING"] = "utf-8"
         result = subprocess.run(
-            ["uvx", "uv", "run", "--no-project", "--no-cache", str(notebook_path)],
+            # ["uvx", "uv", "run", "--no-project", "--no-cache", str(notebook_path)],
+            ["uv", "run", str(notebook_path)],
             check=False,
             capture_output=True,
             text=True,

--- a/uv.lock
+++ b/uv.lock
@@ -154,13 +154,9 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "duckdb" },
-    { name = "folium" },
     { name = "frictionless", extra = ["excel"] },
     { name = "jupyter" },
-    { name = "mapclassify" },
     { name = "marimo" },
-    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "matplotlib", version = "3.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mypy" },
     { name = "nbconvert" },
     { name = "pandas-stubs", version = "2.2.2.240807", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -169,6 +165,10 @@ dev = [
     { name = "sqlglot" },
 ]
 tests = [
+    { name = "folium" },
+    { name = "mapclassify" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest" },
 ]
 
@@ -184,19 +184,21 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "duckdb", specifier = ">=1.2.2" },
-    { name = "folium", specifier = ">=0.17.0" },
     { name = "frictionless", extras = ["excel"], specifier = ">=4.40.8" },
     { name = "jupyter", specifier = ">=1.1.1" },
-    { name = "mapclassify", specifier = ">=2.8.1" },
     { name = "marimo", specifier = ">=0.12.5" },
-    { name = "matplotlib", specifier = ">=3.9.2" },
     { name = "mypy", specifier = ">=1.11.2" },
     { name = "nbconvert", specifier = ">=7.16.6" },
     { name = "pandas-stubs", specifier = ">=2.2.2.240807" },
     { name = "ruff", specifier = ">=0.6.7" },
     { name = "sqlglot", specifier = ">=26.12.1" },
 ]
-tests = [{ name = "pytest", specifier = ">=8.3.3" }]
+tests = [
+    { name = "folium", specifier = ">=0.17.0" },
+    { name = "mapclassify", specifier = ">=2.8.1" },
+    { name = "matplotlib", specifier = ">=3.9.2" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "bleach"
@@ -993,7 +995,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload_time = "2025-04-27T15:29:01.736Z" }
 wheels = [


### PR DESCRIPTION
Previous to this PR, the Kai Tak, HK marimo notebook test ran the notebook in "sandbox" mode. The test would create a new virtual environment just for running the notebook. This virtual environment would that install the dependencies listen in the Kai Tak, HK's inline script dependencies at the top of the notebook Python file. This would cause the latest release of `bedrock-ge` on PyPI to be installed, rather than running the test again the latest code. 